### PR TITLE
Allow multiple needles for the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## Upcoming
+### Added
+- Support for the changelog needle `## Unreleased`
+
 ## v2.1.0 - 2015-03-04
 ### Added
 - `--bugfix` flag that bumps to the next bugfix version

--- a/lib/support/changelog.js
+++ b/lib/support/changelog.js
@@ -12,6 +12,11 @@ var dateFormat = require('dateformat');
 var helper = require('./misc');
 
 var changelog = module.exports = {
+  needles: [
+    '## Upcoming',
+    '## Unreleased'
+  ],
+
   update: function (args) {
     return Bluebird.resolve().then(function () {
       if (changelog.exists() && changelog.needsUpdate()) {
@@ -30,17 +35,24 @@ var changelog = module.exports = {
   },
 
   needsUpdate: function () {
-    return this.read().indexOf('## Upcoming') > -1;
+    var changelog = this.read();
+
+    return this.needles.some(function (needle) {
+      return changelog.indexOf(needle) > -1;
+    });
   },
 
   setVersion: function (version) {
-    var currentContent = this.read();
-    var date           = date;
-    var formattedDate  = dateFormat(date, 'yyyy-mm-dd');
-    var needle         = '## Upcoming';
-    var replacement    = '## v' + version + ' - ' + formattedDate;
+    var content       = this.read();
+    var date          = date;
+    var formattedDate = dateFormat(date, 'yyyy-mm-dd');
+    var replacement   = '## v' + version + ' - ' + formattedDate;
 
-    this.write(currentContent.replace(needle, replacement));
+    this.needles.forEach(function (needle) {
+      content = content.replace(needle, replacement);
+    });
+
+    this.write(content);
   },
 
   read: function () {

--- a/test/support.test.js
+++ b/test/support.test.js
@@ -115,11 +115,15 @@ describe('Support', function () {
         return this.helper.update({ version: '1.2.3' });
       });
 
-      it('inserts the version number if the needle is in the changelog', function () {
-        fs.writeFileSync('/tmp/CHANGELOG.md', '## Upcoming');
-        this.mock.expects('setVersion').once().withArgs('1.2.3');
-        this.mock.expects('commitVersion').once().withArgs('1.2.3');
-        return this.helper.update({ version: '1.2.3' });
+      Support.changelog.needles.forEach(function(needle) {
+        describe('with the needle "' + needle + '"', function () {
+          it('inserts the version number if the needle is in the changelog', function () {
+            fs.writeFileSync('/tmp/CHANGELOG.md', needle);
+            this.mock.expects('setVersion').once().withArgs('1.2.3');
+            this.mock.expects('commitVersion').once().withArgs('1.2.3');
+            return this.helper.update({ version: '1.2.3' });
+          });
+        });
       });
     });
 
@@ -151,33 +155,41 @@ describe('Support', function () {
         expect(this.helper.needsUpdate()).to.be(false);
       });
 
-      it('returns true if the change log contains the expected needle', function () {
-        fs.writeFileSync('/tmp/CHANGELOG.md', '## Upcoming');
-        expect(this.helper.needsUpdate()).to.be(true);
+      Support.changelog.needles.forEach(function(needle) {
+        describe('with the needle "' + needle + '"', function () {
+          it('returns true if the change log contains the expected needle', function () {
+            fs.writeFileSync('/tmp/CHANGELOG.md', needle);
+            expect(this.helper.needsUpdate()).to.be(true);
+          });
+        });
       });
     });
 
     describe('setVersion', function () {
-      beforeEach(function () {
-        fs.writeFileSync('/tmp/CHANGELOG.md', '## Upcoming');
-      });
+      Support.changelog.needles.forEach(function(needle) {
+        describe('with the needle "' + needle + '"', function () {
+          beforeEach(function () {
+            fs.writeFileSync('/tmp/CHANGELOG.md', needle);
+          });
 
-      it('replaces the needle', function () {
-        expect(this.helper.read()).to.contain('## Upcoming');
-        this.helper.setVersion('1.2.3');
-        expect(this.helper.read()).to.not.contain('## Upcoming');
-      });
+          it('replaces the needle', function () {
+            expect(this.helper.read()).to.contain(needle);
+            this.helper.setVersion('1.2.3');
+            expect(this.helper.read()).to.not.contain(needle);
+          });
 
-      it('sets the version', function () {
-        this.helper.setVersion('1.2.3');
-        expect(this.helper.read()).to.contain('## v1.2.3 - ');
-      });
+          it('sets the version', function () {
+            this.helper.setVersion('1.2.3');
+            expect(this.helper.read()).to.contain('## v1.2.3 - ');
+          });
 
-      it('sets the date', function () {
-        var clock = sinon.useFakeTimers();
-        this.helper.setVersion('1.2.3');
-        expect(this.helper.read()).to.contain(' - 1970-01-01');
-        clock.restore();
+          it('sets the date', function () {
+            var clock = sinon.useFakeTimers();
+            this.helper.setVersion('1.2.3');
+            expect(this.helper.read()).to.contain(' - 1970-01-01');
+            clock.restore();
+          });
+        });
       });
     });
   });


### PR DESCRIPTION
This commit adds support for the `## Unreleased` needle.