### PR TITLE
Accept semver keywords as version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## Upcoming
+### Added
+- Accept semver keywords as versions
+
 ## v2.3.0 - 2015-03-11
 ### Added
 - Validate the version string

--- a/lib/support/misc.js
+++ b/lib/support/misc.js
@@ -12,7 +12,7 @@ var pexec = Bluebird.promisify(exec);
 
 var helper = module.exports = {
   parseArgs: function (args) {
-    if (args.bugfix || args.minor || args.major) {
+    if (args.bugfix || args.minor || args.major || !semver.valid(args._[0])) {
       var version = helper.getCurrentVersion();
       var release;
 
@@ -22,6 +22,8 @@ var helper = module.exports = {
         release = 'minor';
       } else if (args.major) {
         release = 'major';
+      } else {
+        release = args._[0];
       }
 
       return { version: semver.inc(version, release) };
@@ -32,7 +34,7 @@ var helper = module.exports = {
 
   validateVersion: function (args) {
     if (!semver.valid(args.version)) {
-      throw new Error('Specified version is not valid: ' + args.version);
+      throw new Error('Specified version is not valid: ' + args._[0]);
     } else if (semver.lte(args.version, helper.getCurrentVersion())) {
       throw new Error('Specified version is smaller than the current one: ' + args.version);
     }

--- a/test/support/misc.test.js
+++ b/test/support/misc.test.js
@@ -68,6 +68,13 @@ describe('Support', function () {
 
         expect(parsed).to.eql({ version: '3.0.0' });
       });
+
+      it('accepts semver keywords as versions', function () {
+        var args   = { _: ['minor'] };
+        var parsed = this.helper.parseArgs(args);
+
+        expect(parsed).to.eql({ version: '2.4.0' });
+      });
     });
 
     describe('validateVersion', function () {
@@ -79,7 +86,7 @@ describe('Support', function () {
 
       it('throws if the version is no version', function () {
         expect(function () {
-          this.helper.validateVersion({ version: 'nomnom' });
+          this.helper.validateVersion({ version: null, _ : ['nomnom'] });
         }.bind(this)).to.throwError(/Specified version is not valid: nomnom/);
       });
 


### PR DESCRIPTION
E.g. `npm_bump minor` bumps the version to the next minor version