### PR TITLE
[feature] Add automatic version detection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,7 @@ sudo: false
 cache:
   directories:
     - node_modules
+
+before_script:
+  - git config --global user.name "Sascha Depold"
+  - git config --global user.email "sdepold@dev.null"

--- a/README.md
+++ b/README.md
@@ -49,6 +49,28 @@ npm_release --minor  # bumps from 1.2.3 to 1.3.0
 npm_release --major  # bumps from 1.2.3 to 2.0.0
 ```
 
+### Automatic change type detection
+
+The flag `--auto` will parse the commits since the last git tag and checks the
+subject and the body of the commit messages for some specific markers:
+
+- `[major]` will generate a major version bump
+- `[minor]`, `[feature]` will generate a minor version bump
+- `[patch]`, `[bugfix]`, `[fix]`  will generate a patch version bump
+
+If no change type is detected – because the markers are missing – you can also
+specify a fallback type which is picked up in such cases:
+
+```
+npm_release --auto --auto-fallback minor
+```
+
+This will bump the minor version in case no marker has been found.
+
+#### Example
+
+TBD
+
 ## Exported functions
 
 ### npm.bump

--- a/README.md
+++ b/README.md
@@ -67,7 +67,17 @@ This will bump the minor version in case no marker has been found.
 
 #### Example
 
-TBD
+Let's assume your lib is currently on version 1.0.0 (aka the package.json contains that particular version
+number and a git tag `v1.0.0` exists). You now commit with the following messages:
+
+```
+[feature] Add new functionality
+[patch] Fix readme
+```
+
+If you run `npm_release --auto` now, it will bump the second version fragment aka
+set the version to `1.1.0`. This happens because of the `[feature]` in one of the
+git commit message.
 
 ## Exported functions
 

--- a/README.md
+++ b/README.md
@@ -21,17 +21,24 @@ This executable is doing the following steps:
 * It checks if your project contains a `CHANGELOG.md` file.
 * If there is a changelog, it will check if the changelog contains the needle `## Upcoming` and replaces it with the new version and the current timestamp.
 * If there is a changelog, it will commit the changes in changelog with the commit message `Add changes in version: v<version>`.
-* It will now update run `npm version` which will set the version of your package.json to the new value, commit the change with the commit message `Bump to version: v<version>` and finally create a tag for the new version á la `v<version>`.
-* It will now push your changes and your tags to the remote server (via git).
+* It will now run `npm version` (which sets the version of your package.json to the new value), commit the change with the commit message `Bump to version: v<version>` and finally create a tag for the new version á la `v<version>`.
+* Finally it pushes your changes and your tags to the remote server (via git).
 
 #### Usage
 
 ```
-npm_bump 1.2.3
-npm_bump --bugfix # bumps from 1.2.3 to 1.2.4
-npm_bump --minor  # bumps from 1.2.3 to 1.3.0
-npm_bump --major  # bumps from 1.2.3 to 2.0.0
+npm_bump 1.2.3 # Usage with a fixed version
+npm_bump --bugfix # Usage with options
 ```
+
+#### Options
+
+- `--bugfix`, `--patch` increases the third fragment of the version string (e.g. 1.2.3 to 1.2.4)
+- `--minor` increases the second fragment of the version string and sets the third fragment to 0 (e.g. 1.2.3 to 1.3.0)
+- `--major` increases the first fragment of the version string and sets the second and third fragment to 0 (e.g. 1.2.3 to 2.0.0)
+- `--skip-push` will disable the pushing to the remote git server
+- `--auto` enables automatic version detection. See below for more information
+- `--auto-fallback` defines the to-be-bumped fragment in case of failing `auto` detection
 
 ### npm_release
 
@@ -39,15 +46,6 @@ This executable is doing the following steps:
 
 - Call `npm_bump`. See the above steps.
 - Release the package to npm via `npm publish`.
-
-#### Usage
-
-```
-npm_release 1.2.3
-npm_release --bugfix # bumps from 1.2.3 to 1.2.4
-npm_release --minor  # bumps from 1.2.3 to 1.3.0
-npm_release --major  # bumps from 1.2.3 to 2.0.0
-```
 
 ### Automatic change type detection
 

--- a/bin/release_tools.js
+++ b/bin/release_tools.js
@@ -9,53 +9,7 @@ var support      = require('../lib/support');
 
 module.exports = {
   init: function (functionName) {
-    var yargs = require('yargs');
-
-    var argv = yargs
-      .usage('Usage: $0 [version] [--bugfix|--minor|--major]')
-      .example('$0 1.2.3', 'Bump version to 1.2.3')
-      .example('$0 --bugfix', 'Bump from 1.2.3 to 1.2.4')
-      .example('$0 --minor', 'Bump from 1.2.3 to 1.3.0')
-      .example('$0 --major', 'Bump from 1.2.3 to 2.0.0')
-      .option('bugfix', {
-        demand:   false,
-        alias:    'b',
-        describe: 'Bump the package to the next bugfix version.'
-      })
-      .option('patch', {
-        demand:   false,
-        alias:    'p',
-        describe: 'Bump the package to the next patch version. This is an alias for --bugfix.'
-      })
-      .option('minor', {
-        demand:   false,
-        alias:    'm',
-        describe: 'Bump the package to the next minor version.'
-      })
-      .option('major', {
-        demand:   false,
-        alias:    'M',
-        describe: 'Bump the package to the next major version.'
-      })
-      .option('auto', {
-        demand:   false,
-        alias:    'a',
-        describe: 'Automatically detect which version fragment needs bump.'
-      })
-      .option('auto-fallback', {
-        demand: false,
-        alias: 'f',
-        describe: 'Defines version fragment which is bumped in case of failed auto detection.',
-        choices: ['major', 'minor', 'patch']
-      })
-      .wrap(150)
-      .argv;
-
-    if ((argv._.length === 0) && !validOptionCount(argv)) {
-      console.log(yargs.help());
-      process.exit(1);
-    }
-
+    var argv = support.cli.init();
     var result = Bluebird.resolve(argv);
 
     if (argv.auto) {
@@ -67,12 +21,6 @@ module.exports = {
     });
   }
 };
-
-function validOptionCount (argv) {
-  return [argv.bugfix, argv.patch, argv.minor, argv.major, argv.auto].filter(function (arg) {
-    return !!arg;
-  }).length === 1;
-}
 
 function autoDetectVersion (fallback) {
   return function () {

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -33,16 +33,16 @@ function logWrap (s, fun) {
     return Bluebird
       .resolve()
       .then(function () {
-        console.log(s + ' ... ');
+        process.stdout.write(s + ' ... ');
       })
       .then(function () {
         return fun.apply(null, args);
       })
       .then(function () {
-        console.log(s + ' ... done.');
+        console.log('done.');
       })
       .catch(function (e) {
-        console.log(s + ' ... failed:');
+        console.log('failed:');
         console.log(e);
 
         throw e;

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -15,8 +15,8 @@ module.exports = {
       .tap(logWrap('Evaluating the version', Support.misc.validateVersion))
       .tap(logWrap('Updating the changelog', Support.changelog.update))
       .tap(logWrap('Updating the package', Support.npm.updatePackage))
-      .tap(logWrap('Pushing changes', Support.git.push))
-      .tap(logWrap('Pushing tags', Support.git.pushTags));
+      .tap(logWrap('Pushing changes', Support.git.push, args.skipPush))
+      .tap(logWrap('Pushing tags', Support.git.pushTags, args.skipPush));
   },
 
   release: function (args) {
@@ -26,7 +26,7 @@ module.exports = {
   }
 };
 
-function logWrap (s, fun) {
+function logWrap (s, fun, skip) {
   return function () {
     var args = [].slice.apply(arguments);
 
@@ -36,10 +36,12 @@ function logWrap (s, fun) {
         process.stdout.write(s + ' ... ');
       })
       .then(function () {
-        return fun.apply(null, args);
+        if (!skip) {
+          return fun.apply(null, args);
+        }
       })
       .then(function () {
-        console.log('done.');
+        console.log(skip ? 'skipped.' : 'done.');
       })
       .catch(function (e) {
         console.log('failed:');

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -1,0 +1,96 @@
+'use strict';
+
+module.exports = {
+  init: function () {
+    var yargs = require('yargs');
+
+    yargs = addUsage(yargs);
+    yargs = addExamples(yargs);
+    yargs = addOptions(yargs);
+    yargs = addMisc(yargs);
+
+    return validateCliCall(yargs);
+  }
+};
+
+function addUsage (args) {
+  return args.usage('Usage: $0 [version] [--bugfix|--minor|--major|--auto]');
+}
+
+function addExamples (args) {
+  return args
+    .example('$0 1.2.3', 'Bump version to 1.2.3')
+    .example('$0 --bugfix', 'Bump from 1.2.3 to 1.2.4')
+    .example('$0 --minor', 'Bump from 1.2.3 to 1.3.0')
+    .example('$0 --major', 'Bump from 1.2.3 to 2.0.0')
+    .example('$0 --auto', 'Detects change type from git commit messages.');
+}
+
+function addOptions (args) {
+  return args
+    .option('bugfix', {
+      demand:   false,
+      alias:    'b',
+      describe: 'Bump the package to the next bugfix version.',
+      boolean: true
+    })
+    .option('patch', {
+      demand:   false,
+      alias:    'p',
+      describe: 'Bump the package to the next patch version. This is an alias for --bugfix.',
+      boolean: true
+    })
+    .option('minor', {
+      demand:   false,
+      alias:    'm',
+      describe: 'Bump the package to the next minor version.',
+      boolean: true
+    })
+    .option('major', {
+      demand:   false,
+      alias:    'M',
+      describe: 'Bump the package to the next major version.',
+      boolean: true
+    })
+    .option('auto', {
+      demand:   false,
+      alias:    'a',
+      describe: 'Automatically detect which version fragment needs bump.',
+      boolean: true
+    })
+    .option('auto-fallback', {
+      demand: false,
+      alias: 'f',
+      describe: 'Defines version fragment which is bumped in case of failed auto detection.',
+      choices: ['major', 'minor', 'patch']
+    })
+    .option('skip-push', {
+      demand: false,
+      describe: 'Disables pushes to git remote server.',
+      boolean: true
+    });
+}
+
+function addMisc (args) {
+  return args
+    .wrap(150)
+    .help('help')
+    .alias('help', 'h');
+}
+
+function validateCliCall (yargs) {
+  var argv = yargs.argv;
+
+  function validOptionCount (argv) {
+    return [argv.bugfix, argv.patch, argv.minor, argv.major, argv.auto].filter(function (arg) {
+      return !!arg;
+    }).length === 1;
+  }
+
+  if ((argv._.length === 0) && !validOptionCount(argv)) {
+    yargs.showHelp();
+    process.exit(1);
+  } else {
+    return argv;
+  }
+}

--- a/lib/support/git.js
+++ b/lib/support/git.js
@@ -1,11 +1,11 @@
 'use strict';
 
-// Local modules
+var Bluebird = require('bluebird');
 var helper = require('./misc');
 
 var LOG_SEPARATOR = '<<-->>';
 
-module.exports = {
+var git = module.exports = {
   push: function () {
     return helper.exec('git push');
   },
@@ -16,9 +16,25 @@ module.exports = {
 
   getCommitsSinceLastVersion: function () {
     var currentVersion = 'v' + helper.getCurrentVersion();
-    var command = 'git log --pretty=format:"%s' + LOG_SEPARATOR + '%b" ' + currentVersion + '..HEAD';
+    var ignoreScope = currentVersion === 'v0.0.0';
+    var tagCommand = 'git show ' + currentVersion;
+    var logAllCommand = 'git log --pretty=format:"%s' + LOG_SEPARATOR + '%b"'
+    var logScopeCommand = logAllCommand + ' ' + currentVersion + '..HEAD';
+    var logCommand = ignoreScope ? logAllCommand : logScopeCommand;
 
-    return helper.exec(command).then(this.parseGitCommits);
+    var result = Bluebird.resolve();
+
+    if (!ignoreScope) {
+      result = result.then(function () {
+        return helper.exec(tagCommand).catch(function () {
+          throw new Error('Unable to find git tag: ' + currentVersion);
+        });
+      });
+    }
+
+    return result.then(function () {
+      return helper.exec(logCommand).then(git.parseGitCommits);;
+    });
   },
 
   parseGitCommits: function (commits) {

--- a/lib/support/git.js
+++ b/lib/support/git.js
@@ -3,6 +3,8 @@
 // Local modules
 var helper = require('./misc');
 
+var LOG_SEPARATOR = '<<-->>';
+
 module.exports = {
   push: function () {
     return helper.exec('git push');
@@ -10,5 +12,76 @@ module.exports = {
 
   pushTags: function () {
     return helper.exec('git push --tags');
+  },
+
+  getCommitsSinceLastVersion: function () {
+    var currentVersion = 'v' + helper.getCurrentVersion();
+    var command = 'git log --pretty=format:"%s' + LOG_SEPARATOR + '%b" ' + currentVersion + '..HEAD';
+
+    return helper.exec(command).then(this.parseGitCommits);
+  },
+
+  parseGitCommits: function (commits) {
+    return commits.filter(function (commit) {
+      return commit.trim() !== '';
+    }).map(function (commit) {
+      var data = commit.split(LOG_SEPARATOR);
+
+      return addChangeType({ subject: data[0], body: data[1] || '' });
+    });
+  },
+
+  detectChangeType: function (commits, fallback) {
+    var changeTypes = commits.reduce(function (acc, commit) {
+      if (commit.changeType) {
+        acc[commit.changeType] = true;
+      }
+
+      return acc;
+    }, { major: false, minor: false, patch: false });
+
+    if (changeTypes.major || (fallback === 'major')) {
+      return { major: true };
+    } else if (changeTypes.minor || (fallback === 'minor')) {
+      return { minor: true };
+    } else if (changeTypes.patch || (fallback === 'patch')) {
+      return { patch: true };
+    } else {
+      throw new Error('No change type detected and no fallback defined!');
+    }
   }
 };
+
+function isInCommit (commit) {
+  return function (needle) {
+    return (commit.subject + commit.body).indexOf('[' + needle + ']') > -1;
+  }
+}
+
+function isMajorChange (commit) {
+  return ['major'].some(isInCommit(commit));
+}
+
+function isMinorChange (commit) {
+  return ['minor', 'feature'].some(isInCommit(commit));
+}
+
+function isPatchChange (commit) {
+  return ['patch', 'bugfix', 'fix'].some(isInCommit(commit));
+}
+
+function getChangeType (commit) {
+  if (isMajorChange(commit)) {
+    return 'major';
+  } else if (isMinorChange(commit)) {
+    return 'minor';
+  } else if (isPatchChange(commit)) {
+    return 'patch';
+  }
+}
+
+function addChangeType (commit) {
+  commit.changeType = getChangeType(commit);
+
+  return commit;
+}

--- a/lib/support/misc.js
+++ b/lib/support/misc.js
@@ -12,6 +12,12 @@ var pexec = Bluebird.promisify(exec);
 
 var helper = module.exports = {
   parseArgs: function (args) {
+    var result = {};
+
+    if (args.skipPush) {
+      result.skipPush = args.skipPush;
+    }
+
     if (args.patch || args.bugfix || args.minor || args.major || !semver.valid(args._[0])) {
       var version = helper.getCurrentVersion();
       var release;
@@ -26,10 +32,12 @@ var helper = module.exports = {
         release = args._[0];
       }
 
-      return { version: semver.inc(version, release) };
+      result.version = semver.inc(version, release);
     } else {
-      return { version: args._[0] };
+      result.version = args._[0];
     }
+
+    return result;
   },
 
   validateVersion: function (args) {
@@ -41,8 +49,16 @@ var helper = module.exports = {
     }
   },
 
-  exec: function (command) {
-    return pexec(command);
+  exec: function (command, options) {
+    return new Bluebird(function (resolve, reject) {
+      exec(command, options || {}, function (err, stdout, stderr) {
+        if (stderr || err) {
+          reject(stderr || err);
+        } else {
+          resolve(stdout.trim().split('\n'));
+        }
+      });
+    });
   },
 
   getCurrentVersion: function () {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A tiny collection of release helpers.",
   "main": "index.js",
   "scripts": {
-    "test": "mocha test/**/*.js test/*.js"
+    "test": "mocha --timeout 10000 test/**/*.js test/*.js"
   },
   "repository": {
     "type": "git",
@@ -30,6 +30,7 @@
     "dateformat": "^1.0.11",
     "require-all": "^1.0.0",
     "semver": "^4.3.1",
+    "xtend": "^4.0.1",
     "yargs": "^6.6.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "dateformat": "^1.0.11",
     "require-all": "^1.0.0",
     "semver": "^4.3.1",
-    "yargs": "^3.3.1"
+    "yargs": "^6.6.0"
   },
   "devDependencies": {
     "expect.js": "^0.3.1",

--- a/test/bin/helper.js
+++ b/test/bin/helper.js
@@ -1,30 +1,58 @@
 'use strict';
 
+var Bluebird = require('bluebird');
 var exec = require('../../lib/support/misc').exec;
 var testDir = "/tmp/release-tools-test";
 
+function execGit (gitCommand, options) {
+  return exec('git -c "user.name=sdepold" -c "user.email=sdepold@dev.null" ' + gitCommand, options);
+}
+
 var helper = module.exports = {
-  bumpAndGetVersion: function (args) {
-    return helper.prepare().then(function () {
-      return helper.callBump(args);
+  bumpAndGetVersion: function (options) {
+    options = options || {};
+
+    return helper.prepare(options).then(function () {
+      return helper.callBump(options);
     }).then(function () {
       return helper.readVersion();
     });
   },
 
-  prepare: function () {
+  prepare: function (options) {
+    var packageVersion = options.packageVersion || '0.0.0';
     return exec('rm -rf ' + testDir).then(function () {
       return exec('mkdir ' + testDir);
     }).then(function () {
-      return exec('echo "{\\"version\\":\\"0.0.0\\"}" > ' + testDir + '/package.json');
+      return exec('echo "{\\"version\\":\\"' + packageVersion + '\\"}" > ' + testDir + '/package.json');
     }).then(function () {
-      return exec('git init .', { cwd: testDir });
+      return execGit('init .', { cwd: testDir });
+    }).then(function () {
+      return helper.createCommits(options.commits || [])
     });
   },
 
-  callBump: function (args) {
-    console.log(process.cwd() + '/bin/npm_bump.js --skip-push ' + (args || ''))
-    return exec(process.cwd() + '/bin/npm_bump.js --skip-push ' + (args || ''), { cwd: testDir });
+  createCommits: function (commits) {
+    return Bluebird.map(commits, function (commit) {
+      var message = (commit.subject + '\n\n' + (commit.body || '')).trim();
+      var commitCommand = 'commit --allow-empty --message "' + message + '"';
+
+      return execGit(commitCommand, { cwd: testDir }).then(function () {
+        if (commit.tag) {
+          return execGit('tag ' + commit.tag, { cwd: testDir });
+        }
+      });
+    }, {
+      concurrency: 1
+    });
+  },
+
+  callBump: function (options) {
+    options = options || {};
+
+    var command = process.cwd() + '/bin/npm_bump.js --skip-push ' + (options.args || '');
+
+    return exec(command, { cwd: testDir });
   },
 
   readVersion: function () {

--- a/test/bin/helper.js
+++ b/test/bin/helper.js
@@ -1,0 +1,34 @@
+'use strict';
+
+var exec = require('../../lib/support/misc').exec;
+var testDir = "/tmp/release-tools-test";
+
+var helper = module.exports = {
+  bumpAndGetVersion: function (args) {
+    return helper.prepare().then(function () {
+      return helper.callBump(args);
+    }).then(function () {
+      return helper.readVersion();
+    });
+  },
+
+  prepare: function () {
+    return exec('rm -rf ' + testDir).then(function () {
+      return exec('mkdir ' + testDir);
+    }).then(function () {
+      return exec('echo "{\\"version\\":\\"0.0.0\\"}" > ' + testDir + '/package.json');
+    }).then(function () {
+      return exec('git init .', { cwd: testDir });
+    });
+  },
+
+  callBump: function (args) {
+    console.log(process.cwd() + '/bin/npm_bump.js --skip-push ' + (args || ''))
+    return exec(process.cwd() + '/bin/npm_bump.js --skip-push ' + (args || ''), { cwd: testDir });
+  },
+
+  readVersion: function () {
+    delete require.cache[require.resolve(testDir + '/package.json')];
+    return require(testDir + '/package.json').version;
+  }
+};

--- a/test/bin/npm_bump.test.js
+++ b/test/bin/npm_bump.test.js
@@ -1,0 +1,47 @@
+/* global describe, it, beforeEach, afterEach */
+'use strict';
+
+// 3rd party modules
+var expect = require('expect.js');
+var sinon = require('sinon');
+
+var helper = require('./helper');
+var bumpAndGetVersion = helper.bumpAndGetVersion;
+var callBump = helper.callBump;
+
+describe('npm_bump', function () {
+  describe('call without args', function () {
+    it('renders the help', function () {
+      return callBump().then(function () {
+        // We should not reach this code...
+        expect(1).to.equal(2);
+      }, function (e) {
+        expect(e).to.contain('--bugfix, -b')
+      });
+    });
+  });
+
+  describe('call with bugfix option', function () {
+    it('bumps the third fragment', function () {
+      return bumpAndGetVersion('--bugfix').then(function (version) {
+        expect(version).to.equal('0.0.1');
+      });
+    });
+  });
+
+  describe('call with minor option', function () {
+    it('bumps the second fragment', function () {
+      return bumpAndGetVersion('--minor').then(function (version) {
+        expect(version).to.equal('0.1.0');
+      });
+    });
+  });
+
+  describe('call with major option', function () {
+    it('bumps the first fragment', function () {
+      return bumpAndGetVersion('--major').then(function (version) {
+        expect(version).to.equal('1.0.0');
+      });
+    });
+  });
+});

--- a/test/support/git.test.js
+++ b/test/support/git.test.js
@@ -1,0 +1,102 @@
+/* global describe, it, beforeEach, afterEach */
+'use strict';
+
+// 3rd party modules
+var expect = require('expect.js');
+var sinon = require('sinon');
+
+// Local modules
+var git = require('../../lib/support').git;
+
+describe('Support', function () {
+  describe('git', function () {
+    describe('parseGitCommits', function () {
+      it('finds major changes in the subject', function () {
+        var commits = ['[major] breaking change<<-->>' ];
+
+        expect(git.parseGitCommits(commits)).to.eql([
+          { subject: '[major] breaking change', body: '', changeType: 'major' }
+        ]);
+      });
+
+      it('finds minor changes in the subject', function () {
+        var commits = ['[minor] feature<<-->>' ];
+
+        expect(git.parseGitCommits(commits)).to.eql([
+          { subject: '[minor] feature', body: '', changeType: 'minor' }
+        ]);
+      });
+
+      it('finds minor changes in the subject with feature fragment', function () {
+        var commits = ['[feature] feature<<-->>' ];
+
+        expect(git.parseGitCommits(commits)).to.eql([
+          { subject: '[feature] feature', body: '', changeType: 'minor' }
+        ]);
+      });
+
+      it('finds minor changes in the subject', function () {
+        var commits = ['[patch] fix<<-->>' ];
+
+        expect(git.parseGitCommits(commits)).to.eql([
+          { subject: '[patch] fix', body: '', changeType: 'patch' }
+        ]);
+      });
+
+      it('splits subject and body', function () {
+        var commits = ['subject<<-->>body'];
+
+        expect(git.parseGitCommits(commits)).to.eql([
+          { subject: 'subject', body: 'body', changeType: undefined }
+        ]);
+      });
+    });
+
+    describe('detectChangeType', function () {
+      it('detects a major change in a list of changes', function () {
+        var commits = [
+          { subject: 'major change', changeType: 'major' },
+          { subject: 'minor change', changeType: 'minor' },
+          { subject: 'patch change', changeType: 'patch' }
+        ];
+
+        expect(git.detectChangeType(commits)).to.eql({ major: true });
+      });
+
+      it('detects a minor change in a list of changes', function () {
+        var commits = [
+          { subject: 'minor change', changeType: 'minor' },
+          { subject: 'patch change', changeType: 'patch' }
+        ];
+
+        expect(git.detectChangeType(commits)).to.eql({ minor: true });
+      });
+
+      it('detects a major change in a list of changes', function () {
+        var commits = [
+          { subject: 'patch change', changeType: 'patch' }
+        ];
+
+        expect(git.detectChangeType(commits)).to.eql({ patch: true });
+      });
+
+      it('throws an error if no change was detected and there is no fallback', function () {
+        var commits = [
+          { subject: 'some change', changeType: undefined }
+        ];
+
+        expect(function () {
+          return git.detectChangeType(commits)
+        }).to.throwException(/No change type detected/);
+      });
+
+      it('respects the fallback if no change was detected', function () {
+        var commits = [
+          { subject: 'some change', changeType: undefined }
+        ];
+
+        expect(git.detectChangeType(commits, 'minor')).to.eql({ minor: true });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Add support for auto-detecting which version fragment to bump:

```
npm_release --auto --auto-fallback minor
```

This will parse the git history and check every commit since the tag that corresponds with the current project version and HEAD. The commit's subject and body will be scanned for certain markers:

- `[major]` will generate a major version bump
- `[minor]`, `[feature]` will generate a minor version bump
- `[patch]`, `[bugfix]`, `[fix]`  will generate a patch version bump
